### PR TITLE
Modify the linker script and Makefile for Mentor Sourcery toolchain

### DIFF
--- a/programs/Lab02_C/ReadSwitches/Makefile
+++ b/programs/Lab02_C/ReadSwitches/Makefile
@@ -4,11 +4,17 @@ ifndef MIPS_ELF_ROOT
 $(error MIPS_ELF_ROOT must be set to point to toolkit installation root)
 endif
 
-CC=mips-mti-elf-gcc
-LD=mips-mti-elf-gcc
-OD=mips-mti-elf-objdump
-OC=mips-mti-elf-objcopy
-SZ=mips-mti-elf-size
+# Imagination CodeScape MIPS SDK
+#GCC_PREFIX = $(MIPS_ELF_ROOT)/bin/mips-mti-elf-
+
+# Mentor Sourcery CodeBench Lite Edition for MIPS ELF
+GCC_PREFIX = /usr/local/mips-2014.05/bin/mips-sde-elf-
+
+CC=$(GCC_PREFIX)gcc
+LD=$(GCC_PREFIX)gcc
+OD=$(GCC_PREFIX)objdump
+OC=$(GCC_PREFIX)objcopy
+SZ=$(GCC_PREFIX)size
 
 #CFLAGS = -O0 -g -EL -c -msoft-float -march=m14kc
 CFLAGS = -O2 -g -EL -c -msoft-float -march=m14kc
@@ -47,16 +53,16 @@ all: FPGA_RAM
 COBJECTS=$(CSOURCES:.c=.o)
 AOBJECTS=$(ASOURCES:.S=.o)
 
-FPGA_RAM : $(AOBJECTS) $(COBJECTS) 
+FPGA_RAM : $(AOBJECTS) $(COBJECTS)
 	$(LD)  $(LDFLAGS) $(AOBJECTS) $(COBJECTS) -o FPGA_Ram.elf
 	$(SZ) FPGA_Ram.elf
 	$(OD) -D -S -l FPGA_Ram.elf > FPGA_Ram_dasm.txt
 	$(OD) -D -z FPGA_Ram.elf > FPGA_Ram_modelsim.txt
 	$(OC) FPGA_Ram.elf -O srec FPGA_Ram.rec
-	
+
 .c.o:
 	$(CC) $(CFLAGS) $< -o $@
-	
+
 .S.o:
 	$(CC) $(CFLAGS) $< -o $@
 

--- a/programs/Lab02_C/ReadSwitches/boot-uhi32.ld
+++ b/programs/Lab02_C/ReadSwitches/boot-uhi32.ld
@@ -4,10 +4,9 @@
 
 ENTRY(_start)
 OUTPUT_FORMAT("elf32-tradlittlemips", "elf32-tradbigmips", "elf32-tradlittlemips")
-GROUP(-lc -luhi -lgcc -lhal)
+GROUP(-lc -lgcc)
 SEARCH_DIR(.)
 __DYNAMIC  =  0;
-STARTUP(crt0.o)
 EXTERN(__exception_entry)
 EXTERN(__getargs)
 
@@ -21,7 +20,7 @@ PROVIDE (__stack = 0);
 /* Size of the memory returned by get_mem_info */
 PROVIDE (__memory_size = 1M);
 
-/* 
+/*
  * 0 = Do not use exception handler present in boot
  * 1 = Use exception handler present in boot if BEV is 0 at startup
  * 2 = Always use exception handler present in boot

--- a/programs/Lab02_C/ReadSwitches/boot.S
+++ b/programs/Lab02_C/ReadSwitches/boot.S
@@ -119,7 +119,7 @@ init_resources:                 # initializes resources for "cpu".
 
     la      ra, all_done        # If main returns then go to all_done:.
     move    a0, zero            # Indicate that there are no arguments available.
-    la      v0, _start          # load the address of the CRT entry point _start.
+    la      v0, main            # load the address of the CRT entry point _start.
     mtc0    v0, $30             # Write ErrorEPC with the address of main
     ehb                         # clear hazards (makes sure write to ErrorPC has completed)
 
@@ -182,4 +182,3 @@ END(__cpu_init)
     mfc0    a0, C0_DESAVE       # Restore a0
 1:  b       1b  /* Stay here */
     nop
-


### PR DESCRIPTION
Skip crt0.o code.
Jump from boot directly into main() routine.

The Sourcery path is embedded into Makefile. 
For Windows, it's probably better to use some environment variable.